### PR TITLE
fix typo in MultiFFXModelFactory.build docstring

### DIFF
--- a/ffx/core.py
+++ b/ffx/core.py
@@ -384,7 +384,7 @@ class MultiFFXModelFactory:
 
         @argument
           train_X -- 2d array of [sample_i][var_i] : float -- training inputs 
-          test_y -- 1d array of [sample_i] : float -- training outputs
+          train_y -- 1d array of [sample_i] : float -- training outputs
           test_X -- 2d array -- testing inputs
           test_y -- 1d array -- testing outputs
           varnames -- list of string -- variable names


### PR DESCRIPTION
This was confusing me for a few moments, so I thought I'd fix it. It's a simple change to a docstring.
