### PR TITLE
Removed 'coef_init' from call to ElasticNetWithTimeout.fit

### DIFF
--- a/ffx/core.py
+++ b/ffx/core.py
@@ -726,7 +726,7 @@ class FFXModelFactory:
             clf = ElasticNetWithTimeout(alpha=alpha, l1_ratio=ss.l1_ratio(), fit_intercept=False,
                                         max_iter=max_iter, **fit_params)
             try:
-                clf.fit(X_unbiased, y_unbiased, coef_init=cur_unbiased_coefs)
+                clf.fit(X_unbiased, y_unbiased)
             except TimeoutError:
                 print '    Regularized update failed. Returning None'
                 return None #failure


### PR DESCRIPTION
 'coef_init' is deprecated, was being ignored in sklearn 1.4, causing lots of warning messages to be printed, and they will remove it in 1.5
