### PR TITLE
Python3 division fix.

### DIFF
--- a/ffx/core.py
+++ b/ffx/core.py
@@ -862,7 +862,7 @@ class FFXModelFactory:
         # alphas = lotsa alphas at beginning, and usual rate for rest
         st, fin = numpy.log10(alpha_max * ss.eps()), numpy.log10(alpha_max)
         alphas1 = numpy.logspace(
-            st, fin, num=ss.numAlphas() * 10)[::-1][:ss.numAlphas() / 4]
+            st, fin, num=ss.numAlphas() * 10)[::-1][:ss.numAlphas() // 4]
         alphas2 = numpy.logspace(st, fin, num=ss.numAlphas())
         alphas = sorted(set(alphas1).union(alphas2), reverse=True)
 


### PR DESCRIPTION
Python3 has a changed division operator, and / always means true division, 
unlike in python2 where it had different behavior for integers and floats, see:
http://www.informit.com/articles/article.aspx?p=1439189&seqNum=2

Anyway, this patch enforces integer division which is required for the slicing.
