### PR TITLE
Prevent a ValueError if the input variable has constant value

### DIFF
--- a/ffx/core.py
+++ b/ffx/core.py
@@ -686,8 +686,8 @@ class FFXModelFactory:
                     if exponent == 1.0 and ss.thresholdOps():
                         minx, maxx = min(X[:, var_i]), max(X[:, var_i])
                         rangex = maxx - minx
-			if rangex == 0:
-		            eps = numpy.nextafter(minx, numpy.inf) - minx
+                        if rangex == 0:
+                            eps = numpy.nextafter(minx, numpy.inf) - minx
                             # 20 = 2 * 10 is the minimum factor, due            
                             # to maxx potentially ending up having              
                             # twice the ulp, and the usage of 1/10 in           

--- a/ffx/core.py
+++ b/ffx/core.py
@@ -686,11 +686,18 @@ class FFXModelFactory:
                     if exponent == 1.0 and ss.thresholdOps():
                         minx, maxx = min(X[:, var_i]), max(X[:, var_i])
                         rangex = maxx - minx
-                        if rangex == 0:
-                            rangex = math.sqrt(numpy.finfo(float).eps) * \
-                                     float(ss.num_thrs_per_var + 1)
-                            minx -= 0.5 * rangex
-                            maxx += 0.5 * rangex
+			if rangex == 0:
+		            eps = numpy.nextafter(minx, numpy.inf) - minx
+                            # 20 = 2 * 10 is the minimum factor, due            
+                            # to maxx potentially ending up having              
+                            # twice the ulp, and the usage of 1/10 in           
+                            # generating thrs                                   
+                            rangex = 20 * (num_thrs_per_var + 1) * eps
+                            # The correct number of steps is recovered          
+                            # by numpy.arange if rangex = 10 (maxx -            
+                            # minx) / 11                                        
+                            minx -= 0.55 * rangex
+                            maxx += 0.55 * rangex
                         stepx = 0.8 * rangex / float(ss.num_thrs_per_var + 1)
                         thrs = numpy.arange(
                             minx + 0.2 * rangex, maxx - 0.2 * rangex + 0.1 * rangex, stepx)

--- a/ffx/core.py
+++ b/ffx/core.py
@@ -686,6 +686,11 @@ class FFXModelFactory:
                     if exponent == 1.0 and ss.thresholdOps():
                         minx, maxx = min(X[:, var_i]), max(X[:, var_i])
                         rangex = maxx - minx
+                        if rangex == 0:
+                            rangex = math.sqrt(numpy.finfo(float).eps) * \
+                                     float(ss.num_thrs_per_var + 1)
+                            minx -= 0.5 * rangex
+                            maxx += 0.5 * rangex
                         stepx = 0.8 * rangex / float(ss.num_thrs_per_var + 1)
                         thrs = numpy.arange(
                             minx + 0.2 * rangex, maxx - 0.2 * rangex + 0.1 * rangex, stepx)

--- a/ffx/core.py
+++ b/ffx/core.py
@@ -692,7 +692,7 @@ class FFXModelFactory:
                             # to maxx potentially ending up having              
                             # twice the ulp, and the usage of 1/10 in           
                             # generating thrs                                   
-                            rangex = 20 * (num_thrs_per_var + 1) * eps
+                            rangex = 20 * (ss.num_thrs_per_var + 1) * eps
                             # The correct number of steps is recovered          
                             # by numpy.arange if rangex = 10 (maxx -            
                             # minx) / 11                                        


### PR DESCRIPTION
Currently, input variables with a constant value will abort with `ValueError: arange: cannot compute length`, due to `numpy.arange()` cannot handling ranges with zero length. This modification adjusts the range min/max such there is a small offset.