### PR TITLE
Corrected issue with scipy/numpy isinf/isnan

### DIFF
--- a/ffx/core/bases.py
+++ b/ffx/core/bases.py
@@ -86,7 +86,7 @@ class OperatorBase(Base):
         elif op == OP_LOG10:
             # safeguard against: log() on values <= 0.0
             mn, mx = min(y_lin), max(y_lin)
-            if mn <= 0.0 or scipy.isnan(mn) or mx == INF or scipy.isnan(mx):
+            if mn <= 0.0 or np.isnan(mn) or mx == INF or np.isnan(mx):
                 ok = False
             else:
                 ya = np.log10(y_lin)

--- a/ffx/core/utils.py
+++ b/ffx/core/utils.py
@@ -84,7 +84,7 @@ def nondominated_indices_2d(cost0s, cost1s):
 
 def y_is_poor(y):
     '''Returns True if y is not usable'''
-    return max(scipy.isinf(y)) or max(scipy.isnan(y))
+    return max(np.isinf(y)) or max(np.isnan(y))
 
 
 def coef_str(x):


### PR DESCRIPTION
Original code had several occurrences of scipy.isnan() and scipy.isinf(); they no longer exist, so the instructions were replaced with the corresponding numpy functions, np.isnan() and np.isinf().